### PR TITLE
create/remove event handlers during connect/disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Indeterminate state support
+
+## Changed
+
+**BREAKING** - Rename `toggle` method to `toggleAll` to check all checkboxes.
+
 ## [1.0.0] - 2020-10-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ In your view:
 ```html
 <%= form_with model: @user, data: { controller: 'checkbox-select-all' } do |f| %>
   <label>
-    <input type="checkbox" data-action="change->checkbox-select-all#toggle" />
+    <input type="checkbox" data-target="checkbox-select-all.checkboxAll" data-action="change->checkbox-select-all#toggleAll" />
     <span>Select All / Deselect All</span>
   </label>
 
   <%= f.collection_check_boxes :team_ids, Team.all, :id, :name do |b| %>
     <%= b.label do %>
-      <%= b.check_box data: { target: 'checkbox-select-all.checkbox' } %>
+      <%= b.check_box data: { target: 'checkbox-select-all.checkbox', action: 'change->checkbox-select-all#toggle' } %>
       <%= b.text %>
     <% end %>
   <% end %>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
       <h1 class="text-center mb-8 text-5xl font-bold">Stimulus Checkbox Select All</h1>
 
       <p class="text-center mb-4">
-        A Stimulus controller for autogrowing textarea.
+        A Stimulus controller for managing checkbox lists.
       </p>
 
       <p class="text-center badges">
@@ -98,28 +98,28 @@
             <tbody>
               <td class="block">
                 <label>
-                  <input id="checkbox-select-all" type="checkbox" data-target="checkbox-select-all.checkboxAll" data-action="change->checkbox-select-all#toggleAll" />
+                  <input id="checkbox-select-all" type="checkbox" data-target="checkbox-select-all.checkboxAll" />
                   <span>Select All / Deselect All</span>
                 </label>
               </td>
 
               <td class="block">
                 <label>
-                  <input type="checkbox" data-target="checkbox-select-all.checkbox" data-action="change->checkbox-select-all#toggle" />
+                  <input type="checkbox" data-target="checkbox-select-all.checkbox" />
                   <span>Team 1</span>
                 </label>
               </td>
 
               <td class="block">
                 <label>
-                  <input type="checkbox" data-target="checkbox-select-all.checkbox" data-action="change->checkbox-select-all#toggle" checked="checked" />
+                  <input type="checkbox" data-target="checkbox-select-all.checkbox" checked="checked" />
                   <span>Team 2</span>
                 </label>
               </td>
 
               <td class="block">
                 <label>
-                  <input type="checkbox" data-target="checkbox-select-all.checkbox" data-action="change->checkbox-select-all#toggle" />
+                  <input type="checkbox" data-target="checkbox-select-all.checkbox" />
                   <span>Team 3</span>
                 </label>
               </td>

--- a/index.html
+++ b/index.html
@@ -98,28 +98,28 @@
             <tbody>
               <td class="block">
                 <label>
-                  <input id="checkbox-select-all" type="checkbox" data-action="change->checkbox-select-all#toggle" />
+                  <input id="checkbox-select-all" type="checkbox" data-target="checkbox-select-all.checkboxAll" data-action="change->checkbox-select-all#toggleAll" />
                   <span>Select All / Deselect All</span>
                 </label>
               </td>
 
               <td class="block">
                 <label>
-                  <input type="checkbox" data-target="checkbox-select-all.checkbox" />
+                  <input type="checkbox" data-target="checkbox-select-all.checkbox" data-action="change->checkbox-select-all#toggle" />
                   <span>Team 1</span>
                 </label>
               </td>
 
               <td class="block">
                 <label>
-                  <input type="checkbox" data-target="checkbox-select-all.checkbox" />
+                  <input type="checkbox" data-target="checkbox-select-all.checkbox" data-action="change->checkbox-select-all#toggle" checked="checked" />
                   <span>Team 2</span>
                 </label>
               </td>
 
               <td class="block">
                 <label>
-                  <input type="checkbox" data-target="checkbox-select-all.checkbox" />
+                  <input type="checkbox" data-target="checkbox-select-all.checkbox" data-action="change->checkbox-select-all#toggle" />
                   <span>Team 3</span>
                 </label>
               </td>

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,19 @@ export default class extends Controller {
   static targets = ['checkboxAll', 'checkbox']
 
   connect () {
-    this.toggle()
+    if (!this.hasCheckboxAllTarget) return
+    this.checkboxAllTarget.addEventListener('change', this.toggleAll)
+    ;[...this.checkboxTargets].forEach(checkbox => checkbox.addEventListener('change', this.refresh))
+    this.refresh()
   }
 
-  toggleAll (e) {
+  disconnect () {
+    if (!this.hasCheckboxAllTarget) return
+    this.checkboxAllTarget.removeEventListener('change', this.toggleAll)
+    ;[...this.checkboxTargets].forEach(checkbox => checkbox.removeEventListener('change', this.refresh))
+  }
+
+  toggleAll = e => {
     e.preventDefault()
 
     this.checkboxTargets.forEach(checkbox => {
@@ -15,9 +24,7 @@ export default class extends Controller {
     })
   }
 
-  toggle () {
-    if (!this.hasCheckboxAllTarget) return
-
+  refresh = () => {
     const checkboxesCount = this.checkboxTargets.length
     const checkboxesCheckedCount = this.checkboxTargets.filter(c => c.checked).length
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,27 @@
 import { Controller } from 'stimulus'
 
 export default class extends Controller {
-  static targets = ['checkbox']
+  static targets = ['checkboxAll', 'checkbox']
 
-  toggle (e) {
+  connect () {
+    this.toggle()
+  }
+
+  toggleAll (e) {
     e.preventDefault()
 
     this.checkboxTargets.forEach(checkbox => {
       checkbox.checked = e.target.checked
     })
+  }
+
+  toggle () {
+    if (!this.hasCheckboxAllTarget) return
+
+    const checkboxesCount = this.checkboxTargets.length
+    const checkboxesCheckedCount = this.checkboxTargets.filter(c => c.checked).length
+
+    this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
+    this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -11,8 +11,12 @@ describe('#checkboxSelectAll', () => {
       () => document.querySelectorAll("[data-target='checkbox-select-all.checkbox']:checked").length
     )
 
-    expect(targetsBefore).toBe(0)
+    expect(targetsBefore).toBe(1)
 
+    // Uncheck all
+    await toggleCheckbox.click()
+
+    // Check all
     await toggleCheckbox.click()
 
     const targetsAfter = await page.evaluate(


### PR DESCRIPTION
I'm a fan of using connect/disconnect to wire up event management instead of forcing the eventual user to attach `data-action` attributes to every element.

This creates a much tighter loop and removes the need for a public API surface beyond just setting targets.