### PR TITLE
Add helpers for getting checked and unchecked elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ import CheckboxSelectAll from "stimulus-checkbox-select-all"
 export default class extends CheckboxSelectAll {
   connect() {
     super.connect()
+    console.log("Do what you want here.")
 
     // Get all checked checkboxes
     this.checked

--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ import CheckboxSelectAll from "stimulus-checkbox-select-all"
 export default class extends CheckboxSelectAll {
   connect() {
     super.connect()
-    console.log("Do what you want here.")
+
+    // Get all checked checkboxes
+    this.checked
+
+    // Get all unchecked checkboxes
+    this.unchecked
   }
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,17 @@ export default class extends Controller {
 
   refresh () {
     const checkboxesCount = this.checkboxTargets.length
-    const checkboxesCheckedCount = this.checkboxTargets.filter(checkbox => checkbox.checked).length
+    const checkboxesCheckedCount = this.checked.length
 
     this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
     this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
+  }
+
+  get checked() {
+    return this.checkboxTargets.filter(checkbox => checkbox.checked)
+  }
+
+  get unchecked() {
+    return this.checkboxTargets.filter(checkbox => !checkbox.checked)
   }
 }


### PR DESCRIPTION
If you're inheriting from this controller, you need access to the checked (and sometimes unchecked) checkboxes often. This adds two helper methods to grab those easily.