### PR TITLE
Trigger change event on checkboxes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export default class extends Controller {
 
     this.checkboxTargets.forEach(checkbox => {
       checkbox.checked = e.target.checked
+      this.triggerChangeEvent(checkbox)
     })
   }
 
@@ -37,6 +38,12 @@ export default class extends Controller {
 
     this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
     this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
+  }
+
+  triggerChangeEvent(checkbox) {
+    const event = document.createEvent('HTMLEvents')
+    event.initEvent('change', false, true)
+    checkbox.dispatchEvent(event)
   }
 
   get checked () {

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default class extends Controller {
 
     this.checkboxTargets.forEach(checkbox => {
       checkbox.checked = e.target.checked
-      this.triggerChangeEvent(checkbox)
+      this.triggerInputEvent(checkbox)
     })
   }
 
@@ -40,9 +40,9 @@ export default class extends Controller {
     this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
   }
 
-  triggerChangeEvent(checkbox) {
+  triggerInputEvent(checkbox) {
     const event = document.createEvent('HTMLEvents')
-    event.initEvent('change', false, true)
+    event.initEvent('input', false, true)
     checkbox.dispatchEvent(event)
   }
 


### PR DESCRIPTION
By default the `checked=` setter doesn't trigger the element's `change` event. This means that any additional behaviors attached to a checkbox won't be properly triggered when using the selectAll. However, we can manually trigger the change, and everything will flow.