### PR TITLE
allow targets to be dynamically added and removed to the DOM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,12 +19,32 @@ export default class extends Controller {
     this.checkboxTargets.forEach(checkbox => checkbox.addEventListener('change', this.refresh))
     this.refresh()
   }
+  
+  checkboxTargetConnected(el){
+    el.addEventListener('change', this.refresh)
+    this.refresh();
+  }
+
+  checkboxAllTargetConnected(el){
+    el.addEventListener('change', this.toggle)
+    this.refresh();
+  }
 
   disconnect (): void {
     if (!this.hasCheckboxAllTarget) return
 
     this.checkboxAllTarget.removeEventListener('change', this.toggle)
     this.checkboxTargets.forEach(checkbox => checkbox.removeEventListener('change', this.refresh))
+  }
+
+  checkboxTargetDisconnected(el){
+    el.removeEventListener('change', this.refresh)
+    this.refresh();
+  }
+
+  checkboxAllTargetDisconnected(el){
+    el.removeEventListener('change', this.toggle)
+    this.refresh();
   }
 
   toggle (e: Event): void {


### PR DESCRIPTION
This is a request to extend use of the the Stimulus lifecycle callbacks, to make the controller function properly when checkbox checkboxAll targets are dynamically added and/or removed from the DOM.
Use cases is dynamically updating list content with Turbo streams in Rails.