### PR TITLE
Add disable indeterminate logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,11 @@ export default class extends Controller {
   hasCheckboxAllTarget: boolean
   checkboxTargets: HTMLInputElement[]
   checkboxAllTarget: HTMLInputElement
+  disableIndeterminateValue: boolean
 
   static targets: string[] = ['checkboxAll', 'checkbox']
+
+  static values: object = {  disableIndeterminate: { type: Boolean, default: false }}
 
   initialize () {
     this.toggle = this.toggle.bind(this)
@@ -50,8 +53,13 @@ export default class extends Controller {
     const checkboxesCount = this.checkboxTargets.length
     const checkboxesCheckedCount = this.checked.length
 
-    this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
-    this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
+    if (this.disableIndeterminateValue) {
+      this.checkboxAllTarget.checked = checkboxesCheckedCount === checkboxesCount;
+    } else {
+      this.checkboxAllTarget.checked = checkboxesCheckedCount > 0
+      this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
+    }
+
   }
 
   triggerInputEvent (checkbox: HTMLInputElement): void {


### PR DESCRIPTION
# Proposal: Add 'disableIndeterminate' logic

## Background

The current Component allows for three states for the "checkbox all": checked, unchecked, and indeterminate. However, some users may want to disallow the indeterminate state, and there's currently no built-in way to do this.

## Proposal

To address this need, I propose adding a new boolean value called disableIndeterminate. By default, this property would be set to false, allowing for the usual behavior of the Component.

However, if the user sets disableIndeterminate to true, like follows: `data-checkbox-select-all-disable-indeterminate-value="true"` the "checkbox all" will no longer have the indeterminate state. 

---

I hope it's okay that I'm submitting a proposal via this pull request. I recently extended the behavior of your component for a project I'm working on, and I believe that my changes could be useful for other users. 

I'm looking forward to hearing your thoughts on my proposal.

Best regards,

Marc López